### PR TITLE
Add map preloader

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     <script src="https://d3js.org/d3.geo.projection.v0.min.js"></script>
 
     <script src="./javascript/barcharts.js" type="text/javascript" charset="utf-8"></script>
-    <script src="./javascript/main.js" type="text/javascript" charset="utf-8"></script>
     <script src="./javascript/maps.js" type="text/javascript" charset="utf-8"></script>
+    <script src="./javascript/main.js" type="text/javascript" charset="utf-8"></script>
   </head>
   <body>
     <header>

--- a/javascript/barcharts.js
+++ b/javascript/barcharts.js
@@ -129,13 +129,13 @@ var renderBarCharts = (function(data, place, totalWidth, leftMargin, rightMargin
   // preloader() sets all containers to their expected height
   // so they don't change size on scroll when render bar charts
   function preloader(place) {
-    console.log("renderBarCharts.preloader() called");
+    // console.log("renderBarCharts.preloader() called");
     // +24 to fix bug, not sure where it comes from
     $(place).height(height+24);
   }
 
   function render() {
-    console.log("renderBarCharts.render() called");
+    // console.log("renderBarCharts.render() called");
 
     // height "auto" to rewrite preloader to avoid bugs
     $(place).height("auto");
@@ -148,7 +148,7 @@ var renderBarCharts = (function(data, place, totalWidth, leftMargin, rightMargin
       .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
     d3.csv(data, type, function(error, data) {
-      console.log("d3.csv called");
+      // console.log("d3.csv called");
 
       // Hide Y ticks labels if the value is 0 and Y axis is displayed
       yAxis.tickFormat(function(d) {

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -73,11 +73,13 @@ $("document").ready(function(){
     allBarCharts.init(ID);
     allBarCharts.preloader(ID);
   });
+  //preloaderMap sets the height of the map so DOM if fixed
+  //for proper anchor when share links like https://.../#Podcast
+  preloaderMap();
 
   // CHECK
   // render bar charts when they appear on screen
   win.scroll(function(event) {
-
     allMods.each(function(i, el) {
       var el = $(el);
       if (el.visible(true)) {
@@ -85,13 +87,13 @@ $("document").ready(function(){
         allBarCharts.check(ID);
       } 
     });
-
   });
   // ---------SCROLL-END----- //
 
   // RESIZE
   // rerender bar charts on window.resize
   win.resize(function() {
+    preloaderMap();
     allMods.each(function(i, el) {
       var ID = $(el).attr('id');
       allBarCharts.resize(ID);

--- a/javascript/maps.js
+++ b/javascript/maps.js
@@ -15,7 +15,7 @@ var minFillSize = 20;
 var mapFill = {
   all: ['num', [20, 100, 500, 1000],'Number of new coders per country.', ['North America', 'Europe', 'Asia', 'South America', 'Africa', 'Oceania'], ['North America', 'Europe', 'Asia', 'South America', 'Africa', 'Oceania'], ['citizen', 'nonCitizen'], ['Citizen', 'Non-Citizen']],
   gender: ['percent', [0.1, 0.15, 0.2, 0.25], 'Proportion of female, trans*, agender and genderqueer new coders.', ['male', 'female', 'ATQ', 'NR'], ['Male', 'Female', 'Trans*, Genderqueer or Agender', 'No response']],
-  ethnicity: ['percent', [0.1, 0.15, 0.2, 0.35], 'Proportion of new coders who are members of an ethnic minority in their country.', ['ethnicMajority', 'ethnicity'], ['Ethnic Majority', 'Ethnic minority']],
+  ethnicity: ['percent', [0.1, 0.15, 0.2, 0.35], 'Proportion of new coders who are ethnic minority in their country.', ['ethnicMajority', 'ethnicity'], ['Ethnic Majority', 'Ethnic minority']],
   age: ['num', [24, 26, 28, 30], 'Average age of new coders per country.', [0, 1, 2, 3, 4, 5], [' - 0-25', ' - 25-26', ' - 27-28', ' - 29-30', ' - 31+', ' no response'], [0, 1, 2, 3, 4, 5], [' - 0-21', ' - 22-25', ' - 26-29', ' - 30-33', ' - 34+', ' no response']]
     };
 // Color assignment
@@ -125,7 +125,7 @@ function sizeChange(activeGraph) {
 //for proper anchor when share links like https://.../#Podcast
 function preloaderMap() {
   var width = document.getElementById('Map').offsetWidth;
-  var heightNew = height(width)+104; //+104 for legend
+  var heightNew = height(width)+70; //70 for legend
   $('#Map').height(heightNew);
 }
 
@@ -199,13 +199,17 @@ function renderMap(activeGraph, json, graphData) {
               .style('background', colors[activeGraph].spectrum[i])
               .text(legendText[i]);
       }
+
       // Map description
       legend.append('p')
             .attr('class','description')
             .text(mapFill[activeGraph][2]);
+
+      if (activeGraph !== "all") {
       legend.append('p')
             .attr('class', 'footnote')
             .text('For countries with at least 20 responses.')
+      }
 
       svg.append('rect')
          .attr({

--- a/javascript/maps.js
+++ b/javascript/maps.js
@@ -114,11 +114,20 @@ function percentify(num,total) {
 function sizeChange(activeGraph) {
   if (!activeGraph) { activeGraph = 'all'; }
   var graphWidth = document.getElementById('Map').offsetWidth;
-  d3.select('#' + activeGraph + '-map-svg g').attr('transform', 'scale(' + graphWidth/width + ")");
+  d3.select('#' + activeGraph + '-map-svg g')
+    .attr('transform', 'scale(' + graphWidth/width + ")");
   d3.select('#' + activeGraph + '-map-svg')
     .attr('height', height(graphWidth));
 }
 // END FUNCTION sizeChange
+
+//preloaderMap sets the height of the map so DOM if fixed
+//for proper anchor when share links like https://.../#Podcast
+function preloaderMap() {
+  var width = document.getElementById('Map').offsetWidth;
+  var heightNew = height(width)+104; //+104 for legend
+  $('#Map').height(heightNew);
+}
 
 function renderMap(activeGraph, json, graphData) {
       // pulls loaded data into worldJSON
@@ -320,7 +329,6 @@ function renderMap(activeGraph, json, graphData) {
 
 }
 // END FUNCTION renderMap
-
 
 /* PRIMARY CALLS */
 /* Load JSON data */

--- a/javascript/maps.js
+++ b/javascript/maps.js
@@ -15,7 +15,7 @@ var minFillSize = 20;
 var mapFill = {
   all: ['num', [20, 100, 500, 1000],'Number of new coders per country.', ['North America', 'Europe', 'Asia', 'South America', 'Africa', 'Oceania'], ['North America', 'Europe', 'Asia', 'South America', 'Africa', 'Oceania'], ['citizen', 'nonCitizen'], ['Citizen', 'Non-Citizen']],
   gender: ['percent', [0.1, 0.15, 0.2, 0.25], 'Proportion of female, trans*, agender and genderqueer new coders.', ['male', 'female', 'ATQ', 'NR'], ['Male', 'Female', 'Trans*, Genderqueer or Agender', 'No response']],
-  ethnicity: ['percent', [0.1, 0.15, 0.2, 0.35], 'Proportion of new coders who are ethnic minority in their country.', ['ethnicMajority', 'ethnicity'], ['Ethnic Majority', 'Ethnic minority']],
+  ethnicity: ['percent', [0.1, 0.15, 0.2, 0.35], 'Proportion of new coders who are from an ethnic minority in their country.', ['ethnicMajority', 'ethnicity'], ['Ethnic Majority', 'Ethnic minority']],
   age: ['num', [24, 26, 28, 30], 'Average age of new coders per country.', [0, 1, 2, 3, 4, 5], [' - 0-25', ' - 25-26', ' - 27-28', ' - 29-30', ' - 31+', ' no response'], [0, 1, 2, 3, 4, 5], [' - 0-21', ' - 22-25', ' - 26-29', ' - 30-33', ' - 34+', ' no response']]
     };
 // Color assignment


### PR DESCRIPTION
[**Website preview is here**](https://samai-software.github.io/2016-new-coder-survey/#Podcast)
- [x] Add map preloader
  - to fix the DOM for proper anchor when share links with ID like: https://freecodecamp.github.io/2016-new-coder-survey/#Podcast
- [x] Delete footnote _20 responses_ for **Location** map

---

@krisgesling, it's a quick fix, so may be later you can make preloader better and more flexible to changes. The idea is to set height to all DOM elements before the user is anchored to a topic from url ID (.../#Podcast).
You don't set height for the map's legend in the code, so I basically set it to 70px, which might be a problem if somebody will change the legend's content or CSS for it and will forget to adjust 70px in map.js.
